### PR TITLE
Type cursors as string

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,5 +1,5 @@
 patch:
-	git apply ./patches/add-env-vars-patch.patch
+	git apply ./patches/*.patch
 
 generate:
 	oapi-codegen -package render openapi.yaml > render.go

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -53,7 +53,6 @@ paths:
                       $ref: '#/components/schemas/owner'
                     cursor:
                       type: string
-                      format: byte
         '401':
           $ref: '#/components/responses/401Unauthorized'
         '406':
@@ -205,7 +204,6 @@ paths:
                       $ref: '#/components/schemas/service'
                     cursor:
                       type: string
-                      format: byte
         '401':
           $ref: '#/components/responses/401Unauthorized'
         '406':
@@ -377,7 +375,6 @@ paths:
                       $ref: '#/components/schemas/deploy'
                     cursor:
                       type: string
-                      format: byte
         '401':
           $ref: '#/components/responses/401Unauthorized'
         '403':
@@ -493,7 +490,6 @@ paths:
                       $ref: '#/components/schemas/envVar'
                     cursor:
                       type: string
-                      format: byte
         '401':
           $ref: '#/components/responses/401Unauthorized'
         '403':
@@ -535,7 +531,6 @@ paths:
                       $ref: '#/components/schemas/envVar'
                     cursor:
                       type: string
-                      format: byte
         '400':
           $ref: '#/components/responses/400BadRequest'
         '401':
@@ -609,7 +604,6 @@ paths:
                       $ref: '#/components/schemas/header'
                     cursor:
                       type: string
-                      format: byte
         '401':
           $ref: '#/components/responses/401Unauthorized'
         '403':
@@ -682,7 +676,6 @@ paths:
                       $ref: '#/components/schemas/route'
                     cursor:
                       type: string
-                      format: byte
         '401':
           $ref: '#/components/responses/401Unauthorized'
         '403':
@@ -764,7 +757,6 @@ paths:
                       $ref: '#/components/schemas/customDomain'
                     cursor:
                       type: string
-                      format: byte
         '400':
           $ref: '#/components/responses/400BadRequest'
         '401':
@@ -1107,7 +1099,6 @@ paths:
                       $ref: '#/components/schemas/job'
                     cursor:
                       type: string
-                      format: byte
                       example: "abc123"
         '400':
           $ref: '#/components/responses/400BadRequest'
@@ -1204,7 +1195,6 @@ components:
       description: Cursor to begin retrieving entries for this query
       schema:
         type: string
-        format: byte
     customDomainIdOrNameParam:
       name: customDomainIdOrName
       in: path

--- a/patches/cursors-as-string.patch
+++ b/patches/cursors-as-string.patch
@@ -1,0 +1,84 @@
+diff --git a/openapi.yaml b/openapi.yaml
+index c458f10..bea19ec 100644
+--- a/openapi.yaml
++++ b/openapi.yaml
+@@ -53,7 +53,6 @@ paths:
+                       $ref: '#/components/schemas/owner'
+                     cursor:
+                       type: string
+-                      format: byte
+         '401':
+           $ref: '#/components/responses/401Unauthorized'
+         '406':
+@@ -205,7 +204,6 @@ paths:
+                       $ref: '#/components/schemas/service'
+                     cursor:
+                       type: string
+-                      format: byte
+         '401':
+           $ref: '#/components/responses/401Unauthorized'
+         '406':
+@@ -377,7 +375,6 @@ paths:
+                       $ref: '#/components/schemas/deploy'
+                     cursor:
+                       type: string
+-                      format: byte
+         '401':
+           $ref: '#/components/responses/401Unauthorized'
+         '403':
+@@ -493,7 +490,6 @@ paths:
+                       $ref: '#/components/schemas/envVar'
+                     cursor:
+                       type: string
+-                      format: byte
+         '401':
+           $ref: '#/components/responses/401Unauthorized'
+         '403':
+@@ -535,7 +531,6 @@ paths:
+                       $ref: '#/components/schemas/envVar'
+                     cursor:
+                       type: string
+-                      format: byte
+         '400':
+           $ref: '#/components/responses/400BadRequest'
+         '401':
+@@ -609,7 +604,6 @@ paths:
+                       $ref: '#/components/schemas/header'
+                     cursor:
+                       type: string
+-                      format: byte
+         '401':
+           $ref: '#/components/responses/401Unauthorized'
+         '403':
+@@ -682,7 +676,6 @@ paths:
+                       $ref: '#/components/schemas/route'
+                     cursor:
+                       type: string
+-                      format: byte
+         '401':
+           $ref: '#/components/responses/401Unauthorized'
+         '403':
+@@ -764,7 +757,6 @@ paths:
+                       $ref: '#/components/schemas/customDomain'
+                     cursor:
+                       type: string
+-                      format: byte
+         '400':
+           $ref: '#/components/responses/400BadRequest'
+         '401':
+@@ -1107,7 +1099,6 @@ paths:
+                       $ref: '#/components/schemas/job'
+                     cursor:
+                       type: string
+-                      format: byte
+                       example: "abc123"
+         '400':
+           $ref: '#/components/responses/400BadRequest'
+@@ -1204,7 +1195,6 @@ components:
+       description: Cursor to begin retrieving entries for this query
+       schema:
+         type: string
+-        format: byte
+     customDomainIdOrNameParam:
+       name: customDomainIdOrName
+       in: path

--- a/render.go
+++ b/render.go
@@ -4966,7 +4966,7 @@ type GetOwnersResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *[]struct {
-		Cursor *[]byte `json:"cursor,omitempty"`
+		Cursor *string `json:"cursor,omitempty"`
 		Owner  *Owner  `json:"owner,omitempty"`
 	}
 	JSON401 *N401Unauthorized
@@ -5338,7 +5338,7 @@ type GetDeploysResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *[]struct {
-		Cursor *[]byte `json:"cursor,omitempty"`
+		Cursor *string `json:"cursor,omitempty"`
 		Deploy *Deploy `json:"deploy,omitempty"`
 	}
 	JSON401 *N401Unauthorized
@@ -5432,7 +5432,7 @@ type GetEnvVarsForServiceResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *[]struct {
-		Cursor *[]byte `json:"cursor,omitempty"`
+		Cursor *string `json:"cursor,omitempty"`
 		EnvVar *EnvVar `json:"envVar,omitempty"`
 	}
 	JSON401 *N401Unauthorized
@@ -5465,7 +5465,7 @@ type UpdateEnvVarsForServiceResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *[]struct {
-		Cursor *[]byte `json:"cursor,omitempty"`
+		Cursor *string `json:"cursor,omitempty"`
 		EnvVar *EnvVar `json:"envVar,omitempty"`
 	}
 	JSON400 *N400BadRequest
@@ -5532,7 +5532,7 @@ type ListJobResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *[]struct {
-		Cursor *[]byte `json:"cursor,omitempty"`
+		Cursor *string `json:"cursor,omitempty"`
 		Job    *Job    `json:"job,omitempty"`
 	}
 	JSON400 *N400BadRequest
@@ -5649,7 +5649,7 @@ type GetRoutesResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON200      *[]struct {
-		Cursor *[]byte `json:"cursor,omitempty"`
+		Cursor *string `json:"cursor,omitempty"`
 		Routes *Route  `json:"routes,omitempty"`
 	}
 	JSON401 *N401Unauthorized
@@ -6036,7 +6036,7 @@ func ParseGetOwnersResponse(rsp *http.Response) (*GetOwnersResponse, error) {
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest []struct {
-			Cursor *[]byte `json:"cursor,omitempty"`
+			Cursor *string `json:"cursor,omitempty"`
 			Owner  *Owner  `json:"owner,omitempty"`
 		}
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
@@ -7032,7 +7032,7 @@ func ParseGetDeploysResponse(rsp *http.Response) (*GetDeploysResponse, error) {
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest []struct {
-			Cursor *[]byte `json:"cursor,omitempty"`
+			Cursor *string `json:"cursor,omitempty"`
 			Deploy *Deploy `json:"deploy,omitempty"`
 		}
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
@@ -7288,7 +7288,7 @@ func ParseGetEnvVarsForServiceResponse(rsp *http.Response) (*GetEnvVarsForServic
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest []struct {
-			Cursor *[]byte `json:"cursor,omitempty"`
+			Cursor *string `json:"cursor,omitempty"`
 			EnvVar *EnvVar `json:"envVar,omitempty"`
 		}
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
@@ -7373,7 +7373,7 @@ func ParseUpdateEnvVarsForServiceResponse(rsp *http.Response) (*UpdateEnvVarsFor
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest []struct {
-			Cursor *[]byte `json:"cursor,omitempty"`
+			Cursor *string `json:"cursor,omitempty"`
 			EnvVar *EnvVar `json:"envVar,omitempty"`
 		}
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
@@ -7550,7 +7550,7 @@ func ParseListJobResponse(rsp *http.Response) (*ListJobResponse, error) {
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest []struct {
-			Cursor *[]byte `json:"cursor,omitempty"`
+			Cursor *string `json:"cursor,omitempty"`
 			Job    *Job    `json:"job,omitempty"`
 		}
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
@@ -7839,7 +7839,7 @@ func ParseGetRoutesResponse(rsp *http.Response) (*GetRoutesResponse, error) {
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
 		var dest []struct {
-			Cursor *[]byte `json:"cursor,omitempty"`
+			Cursor *string `json:"cursor,omitempty"`
 			Routes *Route  `json:"routes,omitempty"`
 		}
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {


### PR DESCRIPTION
to avoid failing to decode them when they contain an underscore